### PR TITLE
Update doctrine orm and dbal dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": ">=5.5.0",
         "symfony/symfony": "~2.8",
-        "doctrine/orm": "~2.5.0",
-        "doctrine/dbal": "~2.5.0",
+        "doctrine/orm": "^2.5.0",
+        "doctrine/dbal": "^2.5.0",
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "dev-staging-php7",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
Accepts versions higher than 2.5 for doctrine/orm and doctrine/dbal